### PR TITLE
Tumor classifier data.

### DIFF
--- a/Unite.Indices.Context/Unite.Indices.Context.csproj
+++ b/Unite.Indices.Context/Unite.Indices.Context.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <ReleaseVersion>13.1.0</ReleaseVersion>
-    <Version>13.1.0</Version>
+    <ReleaseVersion>13.2.0</ReleaseVersion>
+    <Version>13.2.0</Version>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <RepositoryUrl>https://github.com/dkfz-unite/unite-indices</RepositoryUrl>
     <Authors>Valiantsin Ulasau (DKFZ)</Authors>

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/Constants/MaterialFilterNames.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/Constants/MaterialFilterNames.cs
@@ -4,9 +4,7 @@ public class MaterialFilterNames : SpecimenFilterNames
 {
     protected override string Prefix => "Material";
 
-    public string Type => $"{Prefix}.Type";
     public string FixationType => $"{Prefix}.FixationType";
-    public string TumorType => $"{Prefix}.TumorType";
-    public string TumorGrade => $"{Prefix}.TumorGrade";
+    
     public string Source => $"{Prefix}.Source";
 }

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/Constants/SpecimenFilterNames.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/Constants/SpecimenFilterNames.cs
@@ -7,10 +7,20 @@ public class SpecimenFilterNames
     public string Id => $"{Prefix}.Id";
     public string ReferenceId => $"{Prefix}.ReferenceId";
 
+    public string Condition => $"{Prefix}.Condition";
+    public string TumorType => $"{Prefix}.TumorType";
+    public string TumorGrade => $"{Prefix}.TumorGrade";
+    public string TumorSuperfamily => $"{Prefix}.TumorSuperfamily";
+    public string TumorFamily => $"{Prefix}.TumorFamily";
+    public string TumorClass => $"{Prefix}.TumorClass";
+    public string TumorSubclass => $"{Prefix}.TumorSubclass";
+
     public string MgmtStatus => $"{Prefix}.MgmtStatus";
     public string IdhStatus => $"{Prefix}.IhdStatus";
     public string IdhMutation => $"{Prefix}.IdhMutation";
-    public string GeneExpressionSubtype => $"{Prefix}.GeneExpressionSubtype";
+    public string TertStatus => $"{Prefix}.TertStatus";
+    public string TertMutation => $"{Prefix}.TertMutation";
+    public string ExpressionSubtype => $"{Prefix}.ExpressionSubtype";
     public string MethylationSubtype => $"{Prefix}.MethylationSubtype";
     public string GcimpMethylation => $"{Prefix}.GcimpMethylation";
     public string GeneKnockout => $"{Prefix}.GeneKnockout";

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/Criteria/MaterialCriteria.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/Criteria/MaterialCriteria.cs
@@ -4,9 +4,6 @@ namespace Unite.Indices.Search.Services.Filters.Base.Specimens.Criteria;
 
 public record MaterialCriteria : SpecimenCriteria
 {
-    public ValuesCriteria<string> Type { get; set; }
     public ValuesCriteria<string> FixationType { get; set; }
-    public ValuesCriteria<string> TumorType { get; set; }
-    public RangeCriteria<double?> TumorGrade { get; set; }
     public ValuesCriteria<string> Source { get; set; }
 }

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/Criteria/SpecimenCriteria.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/Criteria/SpecimenCriteria.cs
@@ -4,10 +4,19 @@ namespace Unite.Indices.Search.Services.Filters.Base.Specimens.Criteria;
 
 public record SpecimenCriteria : SpecimensCriteria
 {
-    public ValuesCriteria<string> MgmtStatus { get; set; }
-    public ValuesCriteria<string> IdhStatus { get; set; }
+    public ValuesCriteria<string> Condition { get; set; }
+    public ValuesCriteria<string> TumorType { get; set; }
+    public RangeCriteria<double?> TumorGrade { get; set; }
+    public ValuesCriteria<string> TumorSuperfamily { get; set; }
+    public ValuesCriteria<string> TumorFamily { get; set; }
+    public ValuesCriteria<string> TumorClass { get; set; }
+    public ValuesCriteria<string> TumorSubClass { get; set; }
+    public BoolCriteria MgmtStatus { get; set; }
+    public BoolCriteria IdhStatus { get; set; }
     public ValuesCriteria<string> IdhMutation { get; set; }
-    public ValuesCriteria<string> GeneExpressionSubtype { get; set; }
+    public BoolCriteria TertStatus { get; set; }
+    public ValuesCriteria<string> TertMutation { get; set; }
+    public ValuesCriteria<string> ExpressionSubtype { get; set; }
     public ValuesCriteria<string> MethylationSubtype { get; set; }
     public BoolCriteria GcimpMethylation { get; set; }
     public ValuesCriteria<string> GeneKnockout { get; set; }

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/MaterialFilters.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/MaterialFilters.cs
@@ -22,16 +22,6 @@ public class MaterialFilters<T> : SpecimenFilters<T, MaterialIndex> where T : cl
         {
             return;
         }
-        
-        if (IsNotEmpty(criteria.Type))
-        {
-            Add(new EqualityFilter<T, object>(
-                FilterNames.Type,
-                criteria.Type.Not,
-                path.Join(specimen => specimen.Type.Suffix(_keywordSuffix)),
-                criteria.Type.Value
-            ));
-        }
 
         if (IsNotEmpty(criteria.FixationType))
         {
@@ -40,27 +30,6 @@ public class MaterialFilters<T> : SpecimenFilters<T, MaterialIndex> where T : cl
                 criteria.FixationType.Not,
                 path.Join(specimen => specimen.FixationType.Suffix(_keywordSuffix)),
                 criteria.FixationType.Value
-            ));
-        }
-
-        if (IsNotEmpty(criteria.TumorType))
-        {
-            Add(new EqualityFilter<T, object>(
-                FilterNames.TumorType,
-                criteria.TumorType.Not,
-                path.Join(specimen => specimen.TumorType.Suffix(_keywordSuffix)),
-                criteria.TumorType.Value
-            ));
-        }
-
-        if (IsNotEmpty(criteria.TumorGrade))
-        {
-            Add(new RangeFilter<T, double?>(
-                FilterNames.TumorGrade,
-                criteria.TumorGrade.Not,
-                path.Join(specimen => specimen.TumorGrade),
-                criteria.TumorGrade.Value?.From,
-                criteria.TumorGrade.Value?.To
             ));
         }
 

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/MolecularDataFilters.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/MolecularDataFilters.cs
@@ -21,20 +21,20 @@ public class MolecularDataFilters<T> : FiltersCollection<T> where T : class
 
         if (IsNotEmpty(criteria.MgmtStatus))
         {
-            Add(new EqualityFilter<T, object>(
+            Add(new BooleanFilter<T>(
                 FilterNames.MgmtStatus,
                 criteria.MgmtStatus.Not,
-                path.Join(molecularData => molecularData.MgmtStatus.Suffix(_keywordSuffix)),
+                path.Join(molecularData => molecularData.MgmtStatus),
                 criteria.MgmtStatus.Value
             ));
         }
 
         if (IsNotEmpty(criteria.IdhStatus))
         {
-            Add(new EqualityFilter<T, object>(
+            Add(new BooleanFilter<T>(
                 FilterNames.IdhStatus,
                 criteria.IdhStatus.Not,
-                path.Join(molecularData => molecularData.IdhStatus.Suffix(_keywordSuffix)),
+                path.Join(molecularData => molecularData.IdhStatus),
                 criteria.IdhStatus.Value
             ));
         }
@@ -49,13 +49,33 @@ public class MolecularDataFilters<T> : FiltersCollection<T> where T : class
             ));
         }
 
-        if (IsNotEmpty(criteria.GeneExpressionSubtype))
+        if (IsNotEmpty(criteria.TertStatus))
+        {
+            Add(new BooleanFilter<T>(
+                FilterNames.TertStatus,
+                criteria.TertStatus.Not,
+                path.Join(molecularData => molecularData.TertStatus),
+                criteria.TertStatus.Value
+            ));
+        }
+
+        if (IsNotEmpty(criteria.TertMutation))
         {
             Add(new EqualityFilter<T, object>(
-                FilterNames.GeneExpressionSubtype,
-                criteria.GeneExpressionSubtype.Not,
-                path.Join(molecularData => molecularData.GeneExpressionSubtype.Suffix(_keywordSuffix)),
-                criteria.GeneExpressionSubtype.Value
+                FilterNames.TertMutation,
+                criteria.TertMutation.Not,
+                path.Join(molecularData => molecularData.TertMutation.Suffix(_keywordSuffix)),
+                criteria.TertMutation.Value
+            ));
+        }
+
+        if (IsNotEmpty(criteria.ExpressionSubtype))
+        {
+            Add(new EqualityFilter<T, object>(
+                FilterNames.ExpressionSubtype,
+                criteria.ExpressionSubtype.Not,
+                path.Join(molecularData => molecularData.ExpressionSubtype.Suffix(_keywordSuffix)),
+                criteria.ExpressionSubtype.Value
             ));
         }
 

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/SpecimenFilters.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/SpecimenFilters.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Nest;
 using Unite.Essentials.Extensions;
 using Unite.Indices.Entities.Basic.Specimens;
 using Unite.Indices.Search.Engine.Filters;
@@ -13,6 +14,7 @@ public abstract class SpecimenFilters<T, TModel> : FiltersCollection<T>
 {
     protected abstract SpecimenFilterNames FilterNames { get; }
 
+    protected virtual bool IncludeTumorClassification => true;
     protected virtual bool IncludeMolecularData => true;
     protected virtual bool IncludeInterventions => true;
     protected virtual bool IncludeDrugScreenings => true;
@@ -43,6 +45,45 @@ public abstract class SpecimenFilters<T, TModel> : FiltersCollection<T>
                 path.Join(specimen => specimen.ReferenceId),
                 criteria.ReferenceId.Value
             ));
+        }
+
+        if (IsNotEmpty(criteria.Condition))
+        {
+            Add(new EqualityFilter<T, object>(
+                FilterNames.Condition,
+                criteria.Condition.Not,
+                path.Join(specimen => specimen.Condition.Suffix(_keywordSuffix)),
+                criteria.Condition.Value
+            ));
+        }
+
+        if (IsNotEmpty(criteria.TumorType))
+        {
+            Add(new EqualityFilter<T, object>(
+                FilterNames.TumorType,
+                criteria.TumorType.Not,
+                path.Join(specimen => specimen.TumorType.Suffix(_keywordSuffix)),
+                criteria.TumorType.Value
+            ));
+        }
+
+        if (IsNotEmpty(criteria.TumorGrade))
+        {
+            Add(new RangeFilter<T, double?>(
+                FilterNames.TumorGrade,
+                criteria.TumorGrade.Not,
+                path.Join(specimen => specimen.TumorGrade),
+                criteria.TumorGrade.Value?.From,
+                criteria.TumorGrade.Value?.To
+            ));
+        }
+
+        
+        if (IncludeTumorClassification)
+        {
+            var tumorClassificationFilters = new TumorClassificationFilters<T>(criteria, path.Join(specimen => specimen.TumorClassification));
+        
+            Add(tumorClassificationFilters.All());
         }
 
         if (IncludeMolecularData)

--- a/Unite.Indices.Search/Services/Filters/Base/Specimens/TumorClassificationFilters.cs
+++ b/Unite.Indices.Search/Services/Filters/Base/Specimens/TumorClassificationFilters.cs
@@ -1,0 +1,62 @@
+using System.Linq.Expressions;
+using Nest;
+using Unite.Essentials.Extensions;
+using Unite.Indices.Entities.Basic.Specimens;
+using Unite.Indices.Search.Engine.Filters;
+using Unite.Indices.Search.Services.Filters.Base.Specimens.Constants;
+using Unite.Indices.Search.Services.Filters.Base.Specimens.Criteria;
+
+namespace Unite.Indices.Search.Services.Filters.Base.Specimens;
+
+public class TumorClassificationFilters<T> : FiltersCollection<T> where T : class
+{
+    protected SpecimenFilterNames FilterNames = new();
+
+    public TumorClassificationFilters(SpecimenCriteria criteria, Expression<Func<T, TumorClassificationIndex>> path)
+    {
+        if (criteria == null)
+        {
+            return;
+        }
+
+        if (IsNotEmpty(criteria.TumorSuperfamily))
+        {
+            Add(new SimilarityFilter<T, object>(
+                FilterNames.TumorSuperfamily,
+                criteria.TumorSuperfamily.Not,
+                path.Join(classification => classification.Superfamily.Suffix(_keywordSuffix)),
+                criteria.TumorSuperfamily.Value
+           ));
+        }
+
+        if (IsNotEmpty(criteria.TumorFamily))
+        {
+            Add(new SimilarityFilter<T, object>(
+                FilterNames.TumorFamily,
+                criteria.TumorFamily.Not,
+                path.Join(classification => classification.Family.Suffix(_keywordSuffix)),
+                criteria.TumorFamily.Value
+           ));
+        }
+
+        if (IsNotEmpty(criteria.TumorClass))
+        {
+            Add(new SimilarityFilter<T, object>(
+                FilterNames.TumorClass,
+                criteria.TumorClass.Not,
+                path.Join(classification => classification.Class.Suffix(_keywordSuffix)),
+                criteria.TumorClass.Value
+           ));
+        }
+
+        if (IsNotEmpty(criteria.TumorSubClass))
+        {
+            Add(new SimilarityFilter<T, object>(
+                FilterNames.TumorSubclass,
+                criteria.TumorSubClass.Not,
+                path.Join(classification => classification.Subclass.Suffix(_keywordSuffix)),
+                criteria.TumorSubClass.Value
+           ));
+        }
+    }
+}

--- a/Unite.Indices.Search/Unite.Indices.Search.csproj
+++ b/Unite.Indices.Search/Unite.Indices.Search.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <ReleaseVersion>13.1.1</ReleaseVersion>
-    <Version>13.1.1</Version>
+    <ReleaseVersion>13.2.0</ReleaseVersion>
+    <Version>13.2.0</Version>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <RepositoryUrl>https://github.com/dkfz-unite/unite-indices</RepositoryUrl>
     <Authors>Valiantsin Ulasau (DKFZ)</Authors>

--- a/Unite.Indices/Entities/Basic/Specimens/MaterialIndex.cs
+++ b/Unite.Indices/Entities/Basic/Specimens/MaterialIndex.cs
@@ -2,9 +2,6 @@
 
 public class MaterialIndex : SpecimenBaseIndex
 {
-    public string Type { get; set; }
     public string FixationType { get; set; }
-    public string TumorType { get; set; }
-    public double? TumorGrade { get; set; }
     public string Source { get; set; }
 }

--- a/Unite.Indices/Entities/Basic/Specimens/MolecularDataIndex.cs
+++ b/Unite.Indices/Entities/Basic/Specimens/MolecularDataIndex.cs
@@ -2,10 +2,12 @@
 
 public class MolecularDataIndex
 {
-    public string MgmtStatus { get; set; }
-    public string IdhStatus { get; set; }
+    public bool? MgmtStatus { get; set; }
+    public bool? IdhStatus { get; set; }
     public string IdhMutation { get; set; }
-    public string GeneExpressionSubtype { get; set; }
+    public bool? TertStatus { get; set; }
+    public string TertMutation { get; set; }
+    public string ExpressionSubtype { get; set; }
     public string MethylationSubtype { get; set; }
     public bool? GcimpMethylation { get; set; }
     public string[] GeneKnockouts { get; set; }

--- a/Unite.Indices/Entities/Basic/Specimens/SpecimenBaseIndex.cs
+++ b/Unite.Indices/Entities/Basic/Specimens/SpecimenBaseIndex.cs
@@ -7,7 +7,11 @@ public abstract class SpecimenBaseIndex
     public int Id { get; set; }
     public string ReferenceId { get; set; }
     public int? CreationDay { get; set; }
+    public string Condition { get; set; }
+    public string TumorType { get; set; }
+    public double? TumorGrade { get; set; }
 
+    public TumorClassificationIndex TumorClassification { get; set; }
     public MolecularDataIndex MolecularData { get; set; }
     public InterventionIndex[] Interventions { get; set; }
     public DrugScreeningIndex[] DrugScreenings { get; set; }

--- a/Unite.Indices/Entities/Basic/Specimens/SpecimenIndex.cs
+++ b/Unite.Indices/Entities/Basic/Specimens/SpecimenIndex.cs
@@ -8,6 +8,14 @@ public class SpecimenIndex : SpecimenNavIndex
     public XenograftIndex Xenograft { get; set; }
 
 
+    public TumorClassificationIndex GetTumorClassification()
+    {
+        return Material?.TumorClassification ?? 
+               Line?.TumorClassification ?? 
+               Organoid?.TumorClassification ??
+               Xenograft?.TumorClassification;
+    }
+
     public MolecularDataIndex GetMolecularData()
     {
         return Material?.MolecularData ?? 

--- a/Unite.Indices/Entities/Basic/Specimens/TumorClassificationIndex.cs
+++ b/Unite.Indices/Entities/Basic/Specimens/TumorClassificationIndex.cs
@@ -1,0 +1,9 @@
+namespace Unite.Indices.Entities.Basic.Specimens;
+
+public class TumorClassificationIndex
+{
+    public string Superfamily { get; set; }
+    public string Family { get; set; }
+    public string Class { get; set; }
+    public string Subclass { get; set; }
+}

--- a/Unite.Indices/Unite.Indices.csproj
+++ b/Unite.Indices/Unite.Indices.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <ReleaseVersion>13.1.0</ReleaseVersion>
-    <Version>13.1.0</Version>
+    <ReleaseVersion>13.2.0</ReleaseVersion>
+    <Version>13.2.0</Version>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <RepositoryUrl>https://github.com/dkfz-unite/unite-indices</RepositoryUrl>
     <Authors>Valiantsin Ulasau (DKFZ)</Authors>


### PR DESCRIPTION
Added tumor classification fields for specimens.
Simplified Mgmt, Idh and Tert status fields from enum values to boolean, as it's just a flag whether or not those properties are changed.
Simplified gene_expression_subtype to expression_subtype.
Removed Type, TumorType and TumorGrade from Mateiral.
No these are general Specimen properties, where Type is now Condition.
Added tumor classification filters, updated existing filter.